### PR TITLE
Fixed detection of player colliding with self

### DIFF
--- a/Snek/Game.cs
+++ b/Snek/Game.cs
@@ -138,13 +138,19 @@ public class Game
     {
         var nextHeadPosition = _player.NextHeadPosition();
 
-        if (!_grid.IsInBounds(nextHeadPosition) || _player.IsOccupyingPosition(nextHeadPosition))
+        if (!_grid.IsInBounds(nextHeadPosition))
         {
             SetGameState(GameState.GameOver);
             return;
         }
 
         _grid.MovePlayer(nextHeadPosition);
+
+        if (_player.CollidedWithSelf())
+        {
+            SetGameState(GameState.GameOver);
+            return;
+        }
 
         if (EnemyDestroyed())
         {

--- a/Snek/Player.cs
+++ b/Snek/Player.cs
@@ -42,6 +42,6 @@ public class Player : StyledObject
         _ => throw new Exception(),
     };
 
-    public bool IsOccupyingPosition(Position position)
-        => Cells.Any(c => c.Position == position);
+    public bool CollidedWithSelf()
+        => Cells.Count != Cells.Select(c => c.Position).Distinct().Count();
 }


### PR DESCRIPTION
The detection of the player colliding with themself was happening wrong, and being incorrectly detected in the scenario where the player's _next_ head position collides with the players _current_ tail position (not accounting for the tail moving by the time the head reaches that position). 

This fixes the issue. 