### PR TITLE
Different color for players head + fix rendering glitch

### DIFF
--- a/Snek/Attributes/StyledObject.cs
+++ b/Snek/Attributes/StyledObject.cs
@@ -23,5 +23,5 @@ public abstract class StyledObject
     /// <param name="position">The position the cell should occupy.</param>
     /// <returns>The new <see cref="Cell"/> instance.</returns>
     public virtual Cell CreateCell(Position position)
-        => new(position.X, position.Y, BackgroundColor, SpriteColor, Sprite);
+        => new(position, BackgroundColor, SpriteColor, Sprite);
 }

--- a/Snek/Cell.cs
+++ b/Snek/Cell.cs
@@ -10,21 +10,32 @@ public class Cell : StyledObject, IPositioned
     public override ConsoleColor SpriteColor { get; } = ConsoleColor.Black;
     public override char Sprite { get; } = ' ';
 
-    public Cell(int x, int y)
+    public Cell(int x, int y) : this(new Position(x, y))
+    { }
+
+    public Cell(Position position)
     {
-        Position = new Position(x, y);
+        Position = position;
     }
 
     public Cell(int x, int y, ConsoleColor backgroundColor, ConsoleColor foregroundColor)
+        : this(new Position(x, y), backgroundColor, foregroundColor)
+    { }
+
+    public Cell(Position position, ConsoleColor backgroundColor, ConsoleColor foregroundColor)
     {
-        Position = new Position(x, y);
+        Position = position;
         BackgroundColor = backgroundColor;
         SpriteColor = foregroundColor;
     }
 
     public Cell(int x, int y, ConsoleColor backgroundColor, ConsoleColor foregroundColor, char sprite)
+        : this(new Position(x, y), backgroundColor, foregroundColor, sprite)
+    { }
+
+    public Cell(Position position, ConsoleColor backgroundColor, ConsoleColor foregroundColor, char sprite)
     {
-        Position = new Position(x, y);
+        Position = position;
         BackgroundColor = backgroundColor;
         SpriteColor = foregroundColor;
         Sprite = sprite;

--- a/Snek/Emeny.cs
+++ b/Snek/Emeny.cs
@@ -17,6 +17,6 @@ public class Enemy : StyledObject
 
     public Enemy(Position position)
     {
-        Cell = new(position.X, position.Y, BackgroundColor, SpriteColor, Sprite);
+        Cell = new(position, BackgroundColor, SpriteColor, Sprite);
     }
 }

--- a/Snek/Game.cs
+++ b/Snek/Game.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics;
-using System.Timers;
 using Snek.Events;
 using Snek.Extensions;
 
@@ -180,19 +178,13 @@ public class Game
     {
         var nextHeadPosition = _player.NextHeadPosition();
 
-        if (!_grid.IsInBounds(nextHeadPosition))
+        if (!_grid.IsInBounds(nextHeadPosition) || _player.IsOccupyingPosition(nextHeadPosition, true))
         {
             SetGameState(GameState.GameOver);
             return;
         }
 
         _grid.MovePlayer(nextHeadPosition);
-
-        if (_player.CollidedWithSelf())
-        {
-            SetGameState(GameState.GameOver);
-            return;
-        }
 
         if (EnemyDestroyed())
         {

--- a/Snek/GameGrid.cs
+++ b/Snek/GameGrid.cs
@@ -64,18 +64,27 @@ public class GameGrid : StyledObject, IGrid
     public void MovePlayer(Position nextHeadPosition)
     {
         ArgumentNullException.ThrowIfNull(_player);
-        var newHeadCell = _player.CreateCell(nextHeadPosition);
+
+        // The new head position should have the colors flipped
+        var newHeadCell = _player.CreateCell(nextHeadPosition, true);
+
+        // We need to update the cell that is currently the players head, 
+        // Since it's no longer the head it no longer uses the head style
+        var oldHeadCell = _player.CreateCell(_player.Head.Position);
 
         // In order to tell the display that the players tail is no longer on the current tail position
         // (i.e. the players snake has moved by 1 position), we need to create a cell using the grid style 
         // at the current position snakes tail.
         var oldTailCell = CreateCell(_player.Tail.Position);
 
+        // Add the new head cell, update the previous head cell, and remove the tail cell
         _player.Cells.Insert(0, newHeadCell);
+        _player.Cells[1] = oldHeadCell;
         _player.Cells.Remove(_player.Tail);
 
-        OnCellUpdated(newHeadCell);
         OnCellUpdated(oldTailCell);
+        OnCellUpdated(oldHeadCell);
+        OnCellUpdated(newHeadCell);
     }
 
     /// <summary>

--- a/Snek/Player.cs
+++ b/Snek/Player.cs
@@ -19,7 +19,7 @@ public class Player : StyledObject
         Cells = new();
         for (var i = 0; i < initialLength; i++)
         {
-            Cells.Add(new Cell(position.X, position.Y + i, BackgroundColor, SpriteColor, Sprite));
+            Cells.Add(CreateCell(new Position(position.X, position.Y + i), flipColors: i == 0));
         }
         Facing = Direction.North;
     }
@@ -44,4 +44,14 @@ public class Player : StyledObject
 
     public bool CollidedWithSelf()
         => Cells.Count != Cells.Select(c => c.Position).Distinct().Count();
+
+    public bool IsOccupyingPosition(Position position, bool ignoreTail = true)
+        => Cells.Any(c => c.Position == position && (!ignoreTail || position != Tail.Position));
+
+    public Cell CreateCell(Position position, bool flipColors)
+    {
+        if (!flipColors) return base.CreateCell(position);
+
+        return new Cell(position, SpriteColor, BackgroundColor, Sprite);
+    }
 }


### PR DESCRIPTION
- Fixes a rendering glitch when moving the player, caused by rendering the new head cell before the old tail cell
- Fixes an issue/poor design choice where the player would overlap with itself _then_ hit game over
- Redesign snake head to flip the colours, making it easier to see which cell is the head