### PR TITLE
Update the players head cell after turn instruction received

### DIFF
--- a/Snek/Display.cs
+++ b/Snek/Display.cs
@@ -78,7 +78,7 @@ public class Display
     /// <param name="cell">The data to be drawn</param>
     /// <param name="anchor">The position that the cell should be drawn relative to. Defaults to `0,0`</param>
     /// <param name="disableMultipliers">Whether or not multiplication (or rather repetition) of cells should be disabled.</param>
-    public void Draw(Cell cell, Position? anchor = null, bool disableMultipliers = false)
+    private void Draw(Cell cell, Position? anchor = null, bool disableMultipliers = false)
     {
         lock (drawLock)
         {

--- a/Snek/Game.cs
+++ b/Snek/Game.cs
@@ -163,7 +163,7 @@ public class Game
     {
         if (!_player.CanFace(direction)) return;
 
-        _player.Face(direction);
+        _grid.SetPlayerFacing(direction);
     }
 
     /// <summary>

--- a/Snek/GameGrid.cs
+++ b/Snek/GameGrid.cs
@@ -120,4 +120,11 @@ public class GameGrid : StyledObject, IGrid
                 OnCellUpdated(cell);
             }
     }
+
+    public void SetPlayerFacing(Direction direction)
+    {
+        ArgumentNullException.ThrowIfNull(_player);
+        _player.Face(direction);
+        OnCellUpdated(_player.CreateCell(_player.Head.Position, true));
+    }
 }


### PR DESCRIPTION
Currently, when the player presses an input key to change direction, the head of their snake doesnt get updated until the _next_ tick. This means the snake can collide with itself/walls, but the sprite arrows dont reflect this.
![image](https://user-images.githubusercontent.com/58235000/213820367-6f5752bf-048f-41a4-8903-d86e10c2f590.png)

This fix means that the snakes head cell is updated every time the player presses a direction key, so the snake now reflects the move they attempted to make
![image](https://user-images.githubusercontent.com/58235000/213820459-98b273fe-f62c-4274-b60a-860ef97eb11e.png)
