### PR TITLE
Fix to prevent a delay when extending the player tail

### DIFF
--- a/Snek/Game.cs
+++ b/Snek/Game.cs
@@ -184,11 +184,11 @@ public class Game
             return;
         }
 
-        _grid.MovePlayer(nextHeadPosition);
+        var oldTailPosition = _grid.MovePlayer(nextHeadPosition);
 
         if (EnemyDestroyed())
         {
-            HandleEnemyDestroyed();
+            HandleEnemyDestroyed(oldTailPosition);
         }
     }
 
@@ -201,9 +201,10 @@ public class Game
     /// <summary>
     /// Handles the functionality that needs to be executed when the player destroys an enemy.
     /// </summary>
-    private void HandleEnemyDestroyed()
+    private void HandleEnemyDestroyed(Position oldTailPosition)
     {
-        _grid.ExtendPlayerTail();
+        _grid.ExtendPlayerTail(oldTailPosition);
+
         _enemy = new(_grid.GetRandomAvailablePosition());
         _grid.Add(_enemy);
 

--- a/Snek/GameGrid.cs
+++ b/Snek/GameGrid.cs
@@ -30,9 +30,9 @@ public class GameGrid : StyledObject, IGrid
     /// </summary>
     public event CellUpdatedEventHandler? CellUpdated;
 
-    private IEnumerable<Position> AvailablePositions => Cells
+    public IEnumerable<Position> AvailablePositions => Cells
         .Where(cell => (_enemy == null || cell.Position != _enemy.Cell.Position)
-            && (!_player?.Cells?.Any(playerCell => playerCell.Position == cell.Position) ?? true))
+            && (_player == null || !_player.Cells.Any(playerCell => playerCell.Position == cell.Position)))
         .Select(cell => cell.Position);
 
     public GameGrid(int width, int height)
@@ -61,7 +61,7 @@ public class GameGrid : StyledObject, IGrid
     public bool IsInBounds(Position position)
         => position.X >= 0 && position.X < Width && position.Y >= 0 && position.Y < Height;
 
-    public void MovePlayer(Position nextHeadPosition)
+    public Position MovePlayer(Position nextHeadPosition)
     {
         ArgumentNullException.ThrowIfNull(_player);
 
@@ -85,15 +85,17 @@ public class GameGrid : StyledObject, IGrid
         OnCellUpdated(oldTailCell);
         OnCellUpdated(oldHeadCell);
         OnCellUpdated(newHeadCell);
+
+        return oldTailCell.Position;
     }
 
     /// <summary>
     /// Adds an extra cell to the end of the player.
     /// </summary>
-    public void ExtendPlayerTail()
+    public void ExtendPlayerTail(Position position)
     {
         ArgumentNullException.ThrowIfNull(_player);
-        var cell = _player.CreateCell(_player.Tail.Position);
+        var cell = _player.CreateCell(position);
         _player.Cells.Add(cell);
         OnCellUpdated(cell);
     }


### PR DESCRIPTION
There was a delay in extending the player tail after the player destroyed the enemy cell. Essentially this was being caused by extending the the players tail with the current position of the tail, e.g.

- Move player (both head and tail moves forward)
- Player head now overlaps with enemy
- Add new cell to player at the _new_ tail position 

Rather than adding the player cell at the new tail position, we need to add it to the old position.